### PR TITLE
Refactor: Apply SOLID principles to Data Layer and fix Circular Mock logic

### DIFF
--- a/data/src/main/java/com/nexosolar/android/data/repository/InvoiceRepositoryImpl.java
+++ b/data/src/main/java/com/nexosolar/android/data/repository/InvoiceRepositoryImpl.java
@@ -1,137 +1,101 @@
 package com.nexosolar.android.data.repository;
 
-import android.content.SharedPreferences;
-import android.util.Log;
-
 import com.nexosolar.android.data.InvoiceMapper;
 import com.nexosolar.android.data.local.InvoiceDao;
 import com.nexosolar.android.data.local.InvoiceEntity;
-import com.nexosolar.android.data.remote.ApiService;
-import com.nexosolar.android.data.remote.InvoiceResponse;
+import com.nexosolar.android.data.source.InvoiceRemoteDataSource;
 import com.nexosolar.android.domain.models.Invoice;
 import com.nexosolar.android.domain.repository.InvoiceRepository;
 import com.nexosolar.android.domain.repository.RepositoryCallback;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import retrofit2.Call;
-import retrofit2.Callback;
-import retrofit2.Response;
-
 public class InvoiceRepositoryImpl implements InvoiceRepository {
 
-    private static final String TAG = "DEBUG_REPO";
-    private static final String KEY_LAST_MODE_WAS_MOCK = "last_mode_was_mock";
+    private final InvoiceRemoteDataSource remoteDataSource;
+    private final InvoiceDao localDataSource;
+    private final InvoiceMapper mapper;
+    private final ExecutorService executor;
 
-    private final ApiService apiService;
-    private final InvoiceDao invoiceDao;
-    private final SharedPreferences prefs;
-    private final boolean isMockMode;
-    private final ExecutorService executor = Executors.newSingleThreadExecutor();
+    // NUEVO: Bandera para decidir la estrategia de caché
+    private final boolean alwaysReload;
 
-    private final InvoiceMapper invoiceMapper; // <--- NUEVO CAMPO
-
-    public InvoiceRepositoryImpl(ApiService apiService,
-                                 InvoiceDao invoiceDao,
-                                 SharedPreferences prefs,
-                                 boolean isMockMode) {
-        this.apiService = apiService;
-        this.invoiceDao = invoiceDao;
-        this.prefs = prefs;
-        this.isMockMode = isMockMode;
-        this.invoiceMapper = new InvoiceMapper(); // <--- INICIALIZACIÓN (o inyectar)
-
-        checkAndClearIfModeChangedSync();
-    }
-
-    private void checkAndClearIfModeChangedSync() {
-        try {
-            executor.submit(() -> {
-                boolean lastModeWasMock = prefs.getBoolean(KEY_LAST_MODE_WAS_MOCK, false);
-                if (isMockMode != lastModeWasMock) {
-                    Log.w(TAG, "*** CAMBIO DE MODO DETECTADO *** Limpiando BD...");
-                    invoiceDao.deleteAll();
-                    prefs.edit().putBoolean(KEY_LAST_MODE_WAS_MOCK, isMockMode).apply();
-                }
-            }).get();
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+    // Constructor actualizado
+    public InvoiceRepositoryImpl(InvoiceRemoteDataSource remoteDataSource,
+                                 InvoiceDao localDataSource,
+                                 boolean alwaysReload) { // <--- Recibimos la preferencia
+        this.remoteDataSource = remoteDataSource;
+        this.localDataSource = localDataSource;
+        this.mapper = new InvoiceMapper();
+        this.executor = Executors.newSingleThreadExecutor();
+        this.alwaysReload = alwaysReload;
     }
 
     @Override
     public void getFacturas(RepositoryCallback<List<Invoice>> callback) {
         executor.execute(() -> {
-            if (isMockMode) {
-                // MODO MOCK: Forzar refresh
-                refreshFacturas(new RepositoryCallback<Boolean>() {
-                    @Override
-                    public void onSuccess(Boolean result) { readFromDatabase(callback); }
-                    @Override
-                    public void onError(Throwable t) { callback.onError(t); }
-                });
-            } else {
-                // MODO REAL: Cache First
-                List<InvoiceEntity> entities = invoiceDao.getAllList();
-                if (entities != null && !entities.isEmpty()) {
-                    List<Invoice> domainList = invoiceMapper.toDomainList(entities);
-                    callback.onSuccess(domainList);
-                } else {
-                    refreshFacturas(new RepositoryCallback<Boolean>() {
-                        @Override
-                        public void onSuccess(Boolean result) { readFromDatabase(callback); }
-                        @Override
-                        public void onError(Throwable t) { callback.onError(t); }
-                    });
-                }
-            }
-        });
-    }
+            List<InvoiceEntity> localData = localDataSource.getAllList();
+            boolean hasData = localData != null && !localData.isEmpty();
 
-    private void readFromDatabase(RepositoryCallback<List<Invoice>> callback) {
-        executor.execute(() -> {
-            List<InvoiceEntity> entities = invoiceDao.getAllList();
-            List<Invoice> domainList = new ArrayList<>();
-            if (entities != null) {
-                domainList = invoiceMapper.toDomainList(entities);
-                callback.onSuccess(domainList);
+            // LÓGICA CORREGIDA:
+            // Si nos piden recargar siempre (Mock) O si no tenemos datos locales... vamos a red.
+            if (alwaysReload || !hasData) {
+                fetchFromNetwork(callback);
+            } else {
+                // Si es modo real y ya tenemos datos, usamos la caché
+                callback.onSuccess(mapper.toDomainList(localData));
             }
-            callback.onSuccess(domainList);
         });
     }
 
     @Override
     public void refreshFacturas(RepositoryCallback<Boolean> callback) {
-        apiService.getFacturas().enqueue(new Callback<InvoiceResponse>() {
+        remoteDataSource.getFacturas(new RepositoryCallback<List<InvoiceEntity>>() {
             @Override
-            public void onResponse(Call<InvoiceResponse> call, Response<InvoiceResponse> response) {
-                if (response.isSuccessful() && response.body() != null) {
-                    executor.execute(() -> {
-                        try {
-                            if (isMockMode) invoiceDao.deleteAll(); // Solo borrar todo en mock, o según lógica deseada
-                            // Nota: En real quizás quieras un upsert, pero deleteAll es seguro para evitar duplicados simples
-                            if (!isMockMode) invoiceDao.deleteAll();
-
-
-                            List<InvoiceEntity> entities = invoiceMapper.toEntityList(response.body().getFacturas());
-                            invoiceDao.insertAll(entities);
-                            if (callback != null) callback.onSuccess(true);
-                        } catch (Throwable e) {
-                            if (callback != null) callback.onError(e);
-                        }
-                    });
-                } else {
-                    if (callback != null) callback.onSuccess(false);
-                }
+            public void onSuccess(List<InvoiceEntity> entities) {
+                executor.execute(() -> {
+                    saveToDatabase(entities);
+                    if (callback != null) callback.onSuccess(true);
+                });
             }
 
             @Override
-            public void onFailure(Call<InvoiceResponse> call, Throwable t) {
-                if (callback != null) callback.onError(t);
+            public void onError(Throwable error) {
+                if (callback != null) callback.onError(error);
             }
         });
+    }
+
+    private void fetchFromNetwork(RepositoryCallback<List<Invoice>> callback) {
+        remoteDataSource.getFacturas(new RepositoryCallback<List<InvoiceEntity>>() {
+            @Override
+            public void onSuccess(List<InvoiceEntity> entities) {
+                executor.execute(() -> {
+                    saveToDatabase(entities);
+                    callback.onSuccess(mapper.toDomainList(entities));
+                });
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                // MEJORA OPCIONAL: Si falla la red (incluso en Mock), intentamos mostrar caché vieja
+                // en lugar de error vacío.
+                executor.execute(() -> {
+                    List<InvoiceEntity> localData = localDataSource.getAllList();
+                    if (localData != null && !localData.isEmpty()) {
+                        callback.onSuccess(mapper.toDomainList(localData));
+                    } else {
+                        callback.onError(error);
+                    }
+                });
+            }
+        });
+    }
+
+    private void saveToDatabase(List<InvoiceEntity> entities) {
+        localDataSource.deleteAll();
+        localDataSource.insertAll(entities);
     }
 }

--- a/data/src/main/java/com/nexosolar/android/data/source/InvoiceRemoteDataSource.java
+++ b/data/src/main/java/com/nexosolar/android/data/source/InvoiceRemoteDataSource.java
@@ -1,0 +1,10 @@
+package com.nexosolar.android.data.source;
+
+import com.nexosolar.android.data.local.InvoiceEntity;
+import com.nexosolar.android.domain.repository.RepositoryCallback;
+
+import java.util.List;
+
+public interface InvoiceRemoteDataSource {
+    void getFacturas(RepositoryCallback<List<InvoiceEntity>> callback);
+}

--- a/data/src/main/java/com/nexosolar/android/data/source/InvoiceRemoteDataSourceImpl.java
+++ b/data/src/main/java/com/nexosolar/android/data/source/InvoiceRemoteDataSourceImpl.java
@@ -1,0 +1,45 @@
+package com.nexosolar.android.data.source;
+
+import com.nexosolar.android.data.InvoiceMapper;
+import com.nexosolar.android.data.local.InvoiceEntity;
+import com.nexosolar.android.data.remote.ApiService;
+import com.nexosolar.android.data.remote.InvoiceResponse;
+import com.nexosolar.android.domain.repository.RepositoryCallback;
+
+import java.util.List;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+public class InvoiceRemoteDataSourceImpl implements InvoiceRemoteDataSource {
+
+    private final ApiService apiService;
+    private final InvoiceMapper mapper;
+
+    public InvoiceRemoteDataSourceImpl(ApiService apiService) {
+        this.apiService = apiService;
+        this.mapper = new InvoiceMapper();
+    }
+
+    @Override
+    public void getFacturas(RepositoryCallback<List<InvoiceEntity>> callback) {
+        apiService.getFacturas().enqueue(new Callback<InvoiceResponse>() {
+            @Override
+            public void onResponse(Call<InvoiceResponse> call, Response<InvoiceResponse> response) {
+                if (response.isSuccessful() && response.body() != null) {
+                    // Convertimos Response -> Entity aquí
+                    List<InvoiceEntity> entities = mapper.toEntityList(response.body().getFacturas());
+                    callback.onSuccess(entities);
+                } else {
+                    callback.onError(new Exception("Error del servidor: " + response.code()));
+                }
+            }
+
+            @Override
+            public void onFailure(Call<InvoiceResponse> call, Throwable t) {
+                callback.onError(t);
+            }
+        });
+    }
+}


### PR DESCRIPTION

Refactored the data layer to strictly adhere to Clean Architecture and SRP (Single Responsibility Principle).

Key changes:
- Introduced 'InvoiceRemoteDataSource' interface to abstract the remote data source.
- Refactored 'InvoiceRepositoryImpl' to remove configuration logic and UI thread management.
- Updated 'DataModule' to handle environment switching (Mock vs Real) and prevent race conditions when clearing the DB.
- Fixed cache strategy: Mock mode now forces reload to support circular data rotation (Retromock).