### PR TITLE
refactor(app): centralize DataModule instantiation in Application class

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.INTERNET"/>
 
     <application
+        android:name=".NexoSolarApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/nexosolar/android/NexoSolarApplication.java
+++ b/app/src/main/java/com/nexosolar/android/NexoSolarApplication.java
@@ -1,0 +1,30 @@
+package com.nexosolar.android;
+
+import android.app.Application;
+import com.nexosolar.android.data.DataModule;
+
+public class NexoSolarApplication extends Application {
+
+    // Instancia única del módulo de datos
+    private DataModule dataModule;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        // Inicializamos DataModule por defecto
+        boolean useMockDefault = true;
+        dataModule = new DataModule(this, useMockDefault);
+    }
+
+    /**
+     * Permite reiniciar el módulo de datos si cambiamos de modo (Mock <-> Real)
+     */
+    public void switchDataModule(boolean useMock) {
+        dataModule = new DataModule(this, useMock);
+    }
+
+    // Exponemos el DataModule (o sus repositorios)
+    public DataModule getDataModule() {
+        return dataModule;
+    }
+}

--- a/app/src/main/java/com/nexosolar/android/ui/invoices/InvoiceListActivity.java
+++ b/app/src/main/java/com/nexosolar/android/ui/invoices/InvoiceListActivity.java
@@ -11,9 +11,11 @@ import androidx.fragment.app.FragmentTransaction;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.LinearLayoutManager;
 
+import com.nexosolar.android.NexoSolarApplication;
 import com.nexosolar.android.R;
 import com.nexosolar.android.databinding.ActivityInvoiceListBinding;
 import com.nexosolar.android.domain.models.Invoice;
+import com.nexosolar.android.domain.repository.InvoiceRepository;
 
 import java.util.List;
 
@@ -65,8 +67,15 @@ public class InvoiceListActivity extends AppCompatActivity {
      * Inicializa el ViewModel con la factory apropiada según el modo (Mock/Real API).
      */
     private void setupViewModel() {
-        boolean useMock = getIntent().getBooleanExtra("USE_RETROMOCK", false);
-        InvoiceViewModelFactory factory = new InvoiceViewModelFactory(useMock, this);
+        // 1. Obtener la instancia de Application (Casting seguro)
+        NexoSolarApplication app = (NexoSolarApplication) getApplication();
+
+        InvoiceRepository repository = app.getDataModule().provideInvoiceRepository();
+
+        // 3. Inyectar en la Factory
+        InvoiceViewModelFactory factory = new InvoiceViewModelFactory(repository);
+
+        // 4. Obtener ViewModel
         invoiceViewModel = new ViewModelProvider(this, factory).get(InvoiceViewModel.class);
     }
 

--- a/app/src/main/java/com/nexosolar/android/ui/invoices/InvoiceViewModelFactory.java
+++ b/app/src/main/java/com/nexosolar/android/ui/invoices/InvoiceViewModelFactory.java
@@ -1,52 +1,31 @@
 package com.nexosolar.android.ui.invoices;
 
-import android.content.Context;
-
 import androidx.annotation.NonNull;
 import androidx.lifecycle.ViewModel;
 import androidx.lifecycle.ViewModelProvider;
 
-import com.nexosolar.android.data.DataModule;
 import com.nexosolar.android.domain.repository.InvoiceRepository;
 import com.nexosolar.android.domain.usecase.invoice.FilterInvoicesUseCase;
 import com.nexosolar.android.domain.usecase.invoice.GetInvoicesUseCase;
 
-/**
- * InvoiceViewModelFactory
- *
- * Factory para la creación de InvoiceViewModel con inyección de dependencias manual.
- * Gestiona la configuración del repositorio (Mock o Real) y la construcción de Use Cases.
- */
 public class InvoiceViewModelFactory implements ViewModelProvider.Factory {
 
-    // ===== Variables de instancia =====
+    private final InvoiceRepository repository;
 
-    private final boolean useMock;
-    private final Context context;
-
-    // ===== Constructor =====
-
-    public InvoiceViewModelFactory(boolean useMock, Context context) {
-        this.useMock = useMock;
-        this.context = context.getApplicationContext();
+    public InvoiceViewModelFactory(InvoiceRepository repository) {
+        this.repository = repository;
     }
-
-    // ===== Método de creación =====
 
     @NonNull
     @Override
     @SuppressWarnings("unchecked")
     public <T extends ViewModel> T create(@NonNull Class<T> modelClass) {
         if (modelClass.isAssignableFrom(InvoiceViewModel.class)) {
-            DataModule dataModule = new DataModule(context, useMock);
-            InvoiceRepository repository = dataModule.provideInvoiceRepository();
-
-            GetInvoicesUseCase getInvoicesUseCase = new GetInvoicesUseCase(repository);
-            FilterInvoicesUseCase filterInvoicesUseCase = new FilterInvoicesUseCase();
-
-            return (T) new InvoiceViewModel(getInvoicesUseCase, filterInvoicesUseCase);
+            return (T) new InvoiceViewModel(
+                    new GetInvoicesUseCase(repository),
+                    new FilterInvoicesUseCase()
+            );
         }
-
-        throw new IllegalArgumentException("Unknown ViewModel class");
+        throw new IllegalArgumentException("Unknown ViewModel class: " + modelClass.getName());
     }
 }

--- a/app/src/main/java/com/nexosolar/android/ui/main/MainActivity.java
+++ b/app/src/main/java/com/nexosolar/android/ui/main/MainActivity.java
@@ -11,6 +11,7 @@ import androidx.core.text.HtmlCompat;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
 
+import com.nexosolar.android.NexoSolarApplication;
 import com.nexosolar.android.R;
 import com.nexosolar.android.databinding.ActivityMainBinding;
 import com.nexosolar.android.ui.invoices.InvoiceListActivity;
@@ -90,6 +91,10 @@ public class MainActivity extends AppCompatActivity {
         binding.btToggleApi.setChecked(useMock);
         binding.btToggleApi.setOnCheckedChangeListener((buttonView, isChecked) -> {
             useMock = isChecked;
+
+            // ACTUALIZAMOS EL GRAFO DE DEPENDENCIAS GLOBAL
+            ((NexoSolarApplication) getApplication()).switchDataModule(useMock);
+
             String mode = useMock ? "Using RetroMock" : "Using RetroFit";
             Toast.makeText(MainActivity.this, mode, Toast.LENGTH_SHORT).show();
         });


### PR DESCRIPTION
- Move DataModule creation from ViewModelFactories to NexoSolarApplication
- Implement Manual DI pattern using Application as Composition Root
- Remove data layer dependencies from UI factories to adhere to Clean Architecture principles
- Update AndroidManifest to register the custom Application class