### PR TITLE
refactor: migrate domain models to immutable for thread-safety

### DIFF
--- a/data/src/main/java/com/nexosolar/android/data/InstallationMapper.kt
+++ b/data/src/main/java/com/nexosolar/android/data/InstallationMapper.kt
@@ -4,26 +4,30 @@ import com.nexosolar.android.data.remote.InstallationDTO
 import com.nexosolar.android.domain.models.Installation
 
 /**
- * Mapper para convertir InstallationDTO (capa data) a Installation (capa domain)
- * y aislar el dominio de los nombres de atributos del JSON/API.
+ * Mapper para convertir InstallationDTO (capa data) a Installation (capa domain).
+ *
+ * Estrategia:
+ * - Mapeo funcional con constructor directo (no .apply)
+ * - Manejo de nulls con operador Elvis (?:)
+ * - Sin efectos secundarios (función pura)
  */
 object InstallationMapper {
 
     /**
-     * Convierte un DTO de instalación en un modelo de dominio.
+     * Convierte un DTO de instalación en un modelo de dominio inmutable.
      *
-     * @param dto DTO recibido desde la API
+     * @param dto DTO recibido desde la API (puede ser null)
      * @return Installation del dominio, o null si dto es null
      */
     fun toDomain(dto: InstallationDTO?): Installation? {
         if (dto == null) return null
 
-        return Installation().apply {
-            selfConsumptionCode = dto.cau
-            installationStatus = dto.status
-            installationType = dto.type
-            compensation = dto.compensation
-            power = dto.power
-        }
+        return Installation(
+            selfConsumptionCode = dto.cau ?: "",
+            installationStatus = dto.status ?: "",
+            installationType = dto.type ?: "",
+            compensation = dto.compensation ?: "",
+            power = dto.power ?: ""
+        )
     }
 }

--- a/data/src/main/java/com/nexosolar/android/data/InvoiceMapper.kt
+++ b/data/src/main/java/com/nexosolar/android/data/InvoiceMapper.kt
@@ -5,22 +5,27 @@ import com.nexosolar.android.data.remote.InvoiceDto
 import com.nexosolar.android.domain.models.Invoice
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
 
 /**
  * Mapper bidireccional entre modelos de dominio y entidades de base de datos.
  *
  * Responsabilidades:
  * - Transformar InvoiceEntity (capa data) ↔ Invoice (capa domain)
- * - Aislar el dominio de detalles de persistencia y red
- * - Permitir evolución independiente de los modelos en cada capa
+ * - Transformar InvoiceDto (red) → InvoiceEntity (persistencia)
+ * - Aislar el dominio de detalles de persistencia y formato de red
+ * - Manejo robusto de errores de parsing (fechas inválidas)
  *
- * Ubicación en Clean Architecture: reside en la capa data porque necesita
- * conocer tanto los modelos de dominio como las entidades de persistencia,
- * y es responsabilidad de data preparar los datos para el dominio.
+ * Estrategia:
+ * - Mapeo funcional con constructores directos (inmutable)
+ * - Operador Elvis (?:) para valores por defecto
+ * - Funciones de extensión para transformaciones de listas
  */
 object InvoiceMapper {
 
-    // ===== Mapeo de Entidad a Dominio =====
+    private val DATE_FORMATTER = DateTimeFormatter.ofPattern("dd/MM/yyyy")
+
+    // ========== ENTITY → DOMAIN ==========
 
     /**
      * Convierte una entidad de base de datos a modelo de dominio.
@@ -31,39 +36,67 @@ object InvoiceMapper {
     fun toDomain(entity: InvoiceEntity?): Invoice? {
         if (entity == null) return null
 
-        return Invoice().apply {
-            invoiceStatus = entity.estado
-            invoiceAmount = entity.importe
+        return Invoice(
+            invoiceID = entity.id,
+            invoiceStatus = entity.estado,
+            invoiceAmount = entity.importe,
             invoiceDate = entity.fecha
-            // invoiceID = entity.id // Descomentar si el dominio requiere ID
-        }
+        )
     }
 
     /**
      * Convierte una lista de entidades a lista de modelos de dominio.
      *
      * @param entities Lista de entidades de Room
-     * @return Lista de modelos de dominio (vacía si entities es null)
+     * @return Lista de modelos de dominio (vacía si entities es null o vacía)
      */
     fun toDomainList(entities: List<InvoiceEntity>?): List<Invoice> {
         return entities?.mapNotNull { toDomain(it) } ?: emptyList()
     }
 
-    // ===== Mapeo de Dominio a Entidad =====
+    // ========== DOMAIN → ENTITY ==========
 
     /**
      * Convierte un modelo de dominio a entidad de base de datos.
      *
+     * Room genera el ID automáticamente si es autoincrement.
+     * Si necesitas preservar el ID original del servidor, descomenta el campo.
+     *
      * @param invoice Modelo de dominio Invoice
-     * @return Entidad de Room
+     * @return Entidad de Room, o null si invoice es null
      */
     fun toEntity(invoice: Invoice?): InvoiceEntity? {
         if (invoice == null) return null
 
         return InvoiceEntity(
+            id = invoice.invoiceID,           // ← Si Room usa @PrimaryKey(autoGenerate = true), omite esto
             estado = invoice.invoiceStatus ?: "",
             importe = invoice.invoiceAmount,
             fecha = invoice.invoiceDate
+        )
+    }
+
+    // ========== DTO (Red) → ENTITY ==========
+
+    /**
+     * Convierte un DTO de red a entidad de base de datos.
+     * Parsea la fecha del formato "dd/MM/yyyy" a LocalDate.
+     *
+     * Manejo de errores:
+     * - Si la fecha es inválida, usa null (permite guardar sin fecha)
+     * - Alternativa: podrías usar LocalDate.now() como fallback
+     *
+     * @param dto DTO desde la API
+     * @return Entidad de Room, o null si el DTO es null
+     */
+    fun toEntityFromDto(dto: InvoiceDto?): InvoiceEntity? {
+        if (dto == null) return null
+
+        return InvoiceEntity(
+            // id se autogenera en Room, no viene del DTO
+            estado = dto.status ?: "",
+            importe = dto.amount,
+            fecha = parseDate(dto.date)
         )
     }
 
@@ -71,34 +104,60 @@ object InvoiceMapper {
      * Convierte una lista de DTOs de red a entidades de base de datos.
      *
      * @param dtos Lista de InvoiceDto desde la API
-     * @return Lista de entidades Room
+     * @return Lista de entidades Room (descarta DTOs inválidos con mapNotNull)
      */
     fun toEntityListFromDto(dtos: List<InvoiceDto>?): List<InvoiceEntity> {
         return dtos?.mapNotNull { toEntityFromDto(it) } ?: emptyList()
     }
 
+    // ========== DTO (Red) → DOMAIN (DIRECTO - OPCIONAL) ==========
+
     /**
-     * Convierte un DTO de red a entidad de base de datos.
-     * Parsea la fecha del formato "dd/MM/yyyy" a LocalDate.
+     * Convierte directamente un DTO de red a modelo de dominio.
+     * Útil si no necesitas pasar por cache antes de mostrar en UI.
      *
      * @param dto DTO desde la API
-     * @return Entidad de Room, o null si el DTO es null
+     * @return Modelo de dominio, o null si dto es null
      */
-    private fun toEntityFromDto(dto: InvoiceDto?): InvoiceEntity? {
+    fun toDomainFromDto(dto: InvoiceDto?): Invoice? {
         if (dto == null) return null
 
-        val fecha = try {
-            val formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy")
-            LocalDate.parse(dto.date, formatter)
-        } catch (e: Exception) {
-            // Manejo seguro en caso de error de parsing
-            null // o LocalDate.now(), según prefieras
-        }
-
-        return InvoiceEntity(
-            estado = dto.status ?: "",
-            importe = dto.amount,
-            fecha = fecha
+        return Invoice(
+            invoiceID = 0, // La API probablemente no envía ID, se genera en Room
+            invoiceStatus = dto.status,
+            invoiceAmount = dto.amount,
+            invoiceDate = parseDate(dto.date)
         )
+    }
+
+    /**
+     * Convierte lista de DTOs directamente a lista de modelos de dominio.
+     *
+     * @param dtos Lista de DTOs desde la API
+     * @return Lista de modelos de dominio (vacía si dtos es null)
+     */
+    fun toDomainListFromDto(dtos: List<InvoiceDto>?): List<Invoice> {
+        return dtos?.mapNotNull { toDomainFromDto(it) } ?: emptyList()
+    }
+
+    // ========== HELPERS PRIVADOS ==========
+
+    /**
+     * Parsea una fecha en formato "dd/MM/yyyy" a LocalDate.
+     * Manejo robusto de errores: devuelve null si el formato es inválido.
+     *
+     * @param dateString Fecha como String en formato "dd/MM/yyyy"
+     * @return LocalDate parseada, o null si es inválida
+     */
+    private fun parseDate(dateString: String?): LocalDate? {
+        if (dateString.isNullOrBlank()) return null
+
+        return try {
+            LocalDate.parse(dateString, DATE_FORMATTER)
+        } catch (e: DateTimeParseException) {
+            // Log del error (opcional, si usas Logger)
+            // Logger.e("InvoiceMapper", "Invalid date format: $dateString", e)
+            null
+        }
     }
 }

--- a/domain/src/main/java/com/nexosolar/android/domain/models/Installation.kt
+++ b/domain/src/main/java/com/nexosolar/android/domain/models/Installation.kt
@@ -1,36 +1,15 @@
 package com.nexosolar.android.domain.models
 
 /**
- * Modelo de dominio que representa una instalación fotovoltaica.
- * Contiene los datos técnicos y administrativos básicos devueltos por la API.
- * Se utiliza principalmente en la pantalla de Dashboard/Home.
+ * Modelo de dominio que representa una instalación solar.
+ *
+ * Inmutable (vals) para garantizar thread-safety y compatibilidad con Flow.
+ * Data class para aprovechar equals, hashCode, copy y destructuring.
  */
-class Installation {
-    // ===== Getters y Setters =====
-    // ===== Variables de instancia =====
-    var selfConsumptionCode: String? = null
-    var installationStatus: String? = null
-    var installationType: String? = null
-    var compensation: String? = null
-    var power: String? = null
-
-    // ===== Constructores =====
-    /**
-     * Constructor vacío requerido para serialización (Gson/Retrofit).
-     */
-    constructor()
-
-    constructor(
-        cau: String?,
-        status: String?,
-        type: String?,
-        compensation: String?,
-        power: String?
-    ) {
-        this.selfConsumptionCode = cau
-        this.installationStatus = status
-        this.installationType = type
-        this.compensation = compensation
-        this.power = power
-    }
-}
+data class Installation(
+    val selfConsumptionCode: String = "",
+    val installationStatus: String = "",
+    val installationType: String = "",
+    val compensation: String = "",
+    val power: String = ""
+)

--- a/domain/src/main/java/com/nexosolar/android/domain/models/Invoice.kt
+++ b/domain/src/main/java/com/nexosolar/android/domain/models/Invoice.kt
@@ -9,10 +9,10 @@ import java.time.LocalDate
  * Incluye lógica de negocio para transformación de estados.
  */
 data class Invoice(
-    var invoiceID: Int = 0,
-    var invoiceStatus: String? = null,
-    var invoiceAmount: Float = 0f,
-    var invoiceDate: LocalDate? = null
+    val invoiceID: Int = 0,
+    val invoiceStatus: String? = null,
+    val invoiceAmount: Float = 0f,
+    val invoiceDate: LocalDate? = null
 ) : Serializable {
 
     // ===== Propiedades Computadas (Extensiones de Lógica) =====

--- a/domain/src/test/java/com/nexosolar/android/domain/GetInstallationDetailsUseCaseTest.kt
+++ b/domain/src/test/java/com/nexosolar/android/domain/GetInstallationDetailsUseCaseTest.kt
@@ -92,23 +92,24 @@ class GetInstallationDetailsUseCaseTest {
     }
 
     @Test
-    @DisplayName("Repositorio retorna instalación con campos nulos es válido")
-    fun `when repository returns installation with null fields is valid`() = runTest {
-        // GIVEN: Instalación con algunos campos null
-        val installationWithNulls = Installation().apply {
+    @DisplayName("Repositorio retorna instalación con campos vacíos es válido")
+    fun `when repository returns installation with empty fields is valid`() = runTest {
+        // GIVEN: Instalación con solo el CAU, el resto por defecto ("")
+        val installationPartial = Installation(
             selfConsumptionCode = "ES123"
-            // Resto de campos null
-        }
-        `when`(mockRepository.getInstallationDetails()).thenReturn(installationWithNulls)
+            // El resto usa los valores por defecto definidos en el data class
+        )
+
+        `when`(mockRepository.getInstallationDetails()).thenReturn(installationPartial)
 
         // WHEN: Invocamos el use case
         val result = useCase()
 
-        // THEN: Acepta instalaciones con campos null
+        // THEN: Verifica
         assertNotNull(result)
         assertEquals("ES123", result.selfConsumptionCode)
-        assertNull(result.installationStatus)
-        assertNull(result.compensation)
+        assertEquals("", result.installationStatus) // Ahora es string vacío, no null
+        assertEquals("", result.compensation)
     }
 
     // ========== Métodos auxiliares ==========
@@ -117,10 +118,11 @@ class GetInstallationDetailsUseCaseTest {
      * Crea una instalación mock completa para pruebas.
      */
     private fun createMockInstallation(): Installation {
+
         return Installation(
-            cau = "ES0021000000000001JN",
-            status = "Activa",
-            type = "Residencial",
+            selfConsumptionCode = "ES0021000000000001JN",
+            installationStatus = "Activa",
+            installationType = "Residencial",
             compensation = "Con compensación",
             power = "5.5 kW"
         )


### PR DESCRIPTION
- Convert Invoice and Installation to data classes with val properties
- Refactor Mappers to use pure constructors instead of .apply()
- Update unit tests to support immutability
- Prepare codebase for future Kotlin Flow migration