### PR TITLE
Offload invoice processing to background and precompute UI list items

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
+        android:enableOnBackInvokedCallback="true"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"

--- a/app/src/main/java/com/nexosolar/android/NexoSolarApplication.kt
+++ b/app/src/main/java/com/nexosolar/android/NexoSolarApplication.kt
@@ -2,13 +2,29 @@ package com.nexosolar.android
 
 import android.app.Application
 import com.nexosolar.android.core.Logger
+import com.nexosolar.android.data.local.AppDatabase
+import com.nexosolar.android.data.remote.ApiClientManager
 import dagger.hilt.android.HiltAndroidApp
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 
 @HiltAndroidApp
 class NexoSolarApplication : Application() {
 
+    private val warmUpScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
     override fun onCreate() {
         super.onCreate()
         Logger.isDebug = BuildConfig.DEBUG
+
+        warmUpScope.launch {
+            // Precalentamos inicializaciones costosas para evitar jank
+            // al abrir por primera vez pantallas con Room/Retrofit.
+            ApiClientManager.init(this@NexoSolarApplication)
+            ApiClientManager.getApiService(useMock = true, useAlternativeUrl = false)
+            AppDatabase.getInstance(this@NexoSolarApplication).openHelper.writableDatabase
+        }
     }
 }

--- a/app/src/main/java/com/nexosolar/android/ui/invoices/InvoiceUIState.kt
+++ b/app/src/main/java/com/nexosolar/android/ui/invoices/InvoiceUIState.kt
@@ -1,7 +1,7 @@
 package com.nexosolar.android.ui.invoices
 
 import com.nexosolar.android.core.ErrorClassifier
-import com.nexosolar.android.domain.models.Invoice
+import com.nexosolar.android.ui.invoices.models.InvoiceListItemUi
 import com.nexosolar.android.domain.models.InvoiceFilters
 
 /**
@@ -20,7 +20,7 @@ sealed interface InvoiceUIState {
      * @param isRefreshing Indica si hay una recarga en segundo plano (spinner pequeño).
      */
     data class Success(
-        val invoices: List<Invoice>,
+        val invoices: List<InvoiceListItemUi>,
         val isRefreshing: Boolean = false
     ) : InvoiceUIState
 

--- a/app/src/main/java/com/nexosolar/android/ui/invoices/InvoicesScreen.kt
+++ b/app/src/main/java/com/nexosolar/android/ui/invoices/InvoicesScreen.kt
@@ -23,13 +23,13 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.nexosolar.android.R
-import com.nexosolar.android.domain.models.Invoice
+import com.nexosolar.android.domain.models.InvoiceState
 import com.nexosolar.android.ui.invoices.components.InvoiceItem
 import com.nexosolar.android.ui.invoices.components.InvoiceItemSkeleton
 import com.nexosolar.android.ui.invoices.components.NotAvailableDialog
 import com.nexosolar.android.ui.invoices.filter.InvoiceFilterScreen
 import com.nexosolar.android.ui.smartsolar.components.ErrorView
-import java.time.LocalDate
+import com.nexosolar.android.ui.invoices.models.InvoiceListItemUi
 
 // =================================================================
 // 1. ROUTE
@@ -198,7 +198,7 @@ private fun InvoiceContent(
                     ) {
                         items(
                             items = uiState.invoices,
-                            key = { it.invoiceID }
+                            key = { it.invoiceId }
                         ) { invoice ->
                             InvoiceItem(
                                 invoice = invoice,
@@ -293,11 +293,11 @@ private fun InvoiceScreenSuccessPreview() {
     InvoiceScreen(
         uiState = InvoiceUIState.Success(
             invoices = listOf(
-                Invoice(invoiceID = 1, invoiceAmount = 54.56f, invoiceDate = LocalDate.of(2020, 8, 31), invoiceStatus = "Pendiente de pago"),
-                Invoice(invoiceID = 2, invoiceAmount = 67.54f, invoiceDate = LocalDate.of(2020, 7, 31), invoiceStatus = "Pagada"),
-                Invoice(invoiceID = 3, invoiceAmount = 56.38f, invoiceDate = LocalDate.of(2020, 6, 22), invoiceStatus = "Anulada"),
-                Invoice(invoiceID = 4, invoiceAmount = 150.75f, invoiceDate = LocalDate.of(2024, 5, 12), invoiceStatus = "Cuota fija"),
-                Invoice(invoiceID = 5, invoiceAmount = 99.99f, invoiceDate = LocalDate.of(2024, 6, 8), invoiceStatus = "Plan de pago"),
+                InvoiceListItemUi(invoiceId = 1, state = InvoiceState.PENDING, formattedDate = "31 Ago 2020", formattedAmount = "54.56 €"),
+                InvoiceListItemUi(invoiceId = 2, state = InvoiceState.PAID, formattedDate = "31 Jul 2020", formattedAmount = "67.54 €"),
+                InvoiceListItemUi(invoiceId = 3, state = InvoiceState.CANCELLED, formattedDate = "22 Jun 2020", formattedAmount = "56.38 €"),
+                InvoiceListItemUi(invoiceId = 4, state = InvoiceState.FIXED_FEE, formattedDate = "12 May 2024", formattedAmount = "150.75 €"),
+                InvoiceListItemUi(invoiceId = 5, state = InvoiceState.PAYMENT_PLAN, formattedDate = "08 Jun 2024", formattedAmount = "99.99 €"),
             )
         ),
         onRefresh = {},

--- a/app/src/main/java/com/nexosolar/android/ui/invoices/components/InvoiceItem.kt
+++ b/app/src/main/java/com/nexosolar/android/ui/invoices/components/InvoiceItem.kt
@@ -22,21 +22,18 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.nexosolar.android.R
-import com.nexosolar.android.core.DateUtils
-import com.nexosolar.android.domain.models.Invoice
+import com.nexosolar.android.ui.invoices.models.InvoiceListItemUi
 import com.nexosolar.android.domain.models.InvoiceState
 import com.nexosolar.android.ui.theme.NexoSolarTheme
-import java.time.LocalDate
-import java.util.Locale
 
 
 
 @Composable
 fun InvoiceItem(
-    invoice: Invoice,
+    invoice: InvoiceListItemUi,
     onClick: () -> Unit
 ) {
-    val isPaid = invoice.estadoEnum == InvoiceState.PAID
+    val isPaid = invoice.state == InvoiceState.PAID
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -55,7 +52,7 @@ fun InvoiceItem(
                 modifier = Modifier.weight(1f)
             ) {
                 Text(
-                    text = DateUtils.formatDate(invoice.invoiceDate).ifEmpty { stringResource(R.string.sin_fecha) },
+                    text = invoice.formattedDate.ifEmpty { stringResource(R.string.sin_fecha) },
                     color = Color.Black,
                     fontSize = dimensionResource(id = R.dimen.invoice_item_date_text_size).value.sp,
                     fontWeight = FontWeight.Normal,
@@ -66,11 +63,11 @@ fun InvoiceItem(
                     )
                 )
 
-                if (invoice.estadoEnum != InvoiceState.PAID) {
+                if (invoice.state != InvoiceState.PAID) {
                     Spacer(modifier = Modifier.height(4.dp))
                     Text(
-                        text = stringResource(id = getStatusTextRes(invoice.estadoEnum)),
-                        color = getStatusColor(invoice.estadoEnum),
+                        text = stringResource(id = getStatusTextRes(invoice.state)),
+                        color = getStatusColor(invoice.state),
                         fontSize = dimensionResource(id = R.dimen.invoice_item_state_text_size).value.sp,
                         modifier = Modifier.padding(
                             start = dimensionResource(id = R.dimen.invoice_item_state_margin_start),
@@ -95,7 +92,7 @@ fun InvoiceItem(
                 horizontalArrangement = Arrangement.End
             ) {
                 Text(
-                    text = String.format(Locale.getDefault(), "%.2f €", invoice.invoiceAmount),
+                    text = invoice.formattedAmount,
                     color = Color.Black,
                     fontSize = dimensionResource(id = R.dimen.invoice_item_amount_text_size).value.sp,
                     fontWeight = FontWeight.Normal,
@@ -151,10 +148,11 @@ private fun getStatusColor(state: InvoiceState): Color {
 private fun InvoiceItemPendingPreview() {
     NexoSolarTheme {
         InvoiceItem(
-            invoice = Invoice(
-                invoiceAmount = 150.50f,
-                invoiceDate = LocalDate.of(2023, 9, 10),
-                invoiceStatus = "Pendiente de pago" // String raw, pero el enum lo pilla
+            invoice = InvoiceListItemUi(
+                invoiceId = 1,
+                state = InvoiceState.PENDING,
+                formattedDate = "10 Sep 2023",
+                formattedAmount = "150.50 €"
             ),
             onClick = {}
         )
@@ -166,10 +164,11 @@ private fun InvoiceItemPendingPreview() {
 private fun InvoiceItemPaidPreview() {
     NexoSolarTheme {
         InvoiceItem(
-            invoice = Invoice(
-                invoiceAmount = 89.99f,
-                invoiceDate = LocalDate.of(2023, 10, 25),
-                invoiceStatus = "Pagada" // Debería mapear a PAID
+            invoice = InvoiceListItemUi(
+                invoiceId = 2,
+                state = InvoiceState.PAID,
+                formattedDate = "25 Oct 2023",
+                formattedAmount = "89.99 €"
             ),
             onClick = {}
         )

--- a/app/src/main/java/com/nexosolar/android/ui/invoices/models/InvoiceListItemUi.kt
+++ b/app/src/main/java/com/nexosolar/android/ui/invoices/models/InvoiceListItemUi.kt
@@ -1,0 +1,11 @@
+package com.nexosolar.android.ui.invoices.models
+
+import com.nexosolar.android.domain.models.InvoiceState
+
+data class InvoiceListItemUi(
+    val invoiceId: Int,
+    val state: InvoiceState,
+    val formattedDate: String,
+    val formattedAmount: String
+)
+

--- a/app/src/main/java/com/nexosolar/android/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/nexosolar/android/ui/main/MainActivity.kt
@@ -4,28 +4,18 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.animation.AnimatedContentTransitionScope
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.runtime.getValue
-import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.nexosolar.android.ui.invoices.InvoiceRoute
-import com.nexosolar.android.ui.smartsolar.InstallationViewModel
 import com.nexosolar.android.ui.smartsolar.SmartSolarRoute
-import com.nexosolar.android.ui.smartsolar.SmartSolarScreen
-import com.nexosolar.android.ui.smartsolar.details.DetailsScreen
-import com.nexosolar.android.ui.smartsolar.energy.EnergyScreen
-import com.nexosolar.android.ui.smartsolar.installation.InstallationScreen
 import com.nexosolar.android.ui.theme.NexoSolarTheme
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
@@ -37,11 +27,7 @@ class MainActivity : ComponentActivity() {
                 // CAMBIO CLAVE: El startDestination debe ser "main_menu"
                 NavHost(
                     navController = navController,
-                    startDestination = "main_menu",
-                    enterTransition = { fadeIn(animationSpec = tween(500)) },
-                    exitTransition = { fadeOut(animationSpec = tween(500)) },
-                    popEnterTransition = { fadeIn(animationSpec = tween(500)) },
-                    popExitTransition = { fadeOut(animationSpec = tween(500)) }
+                    startDestination = "main_menu"
                 ) {
                     // 1. Pantalla de Inicio
                     composable("main_menu") {


### PR DESCRIPTION
### Motivation
- Reduce first-navigation jank by moving invoice filtering/mapping work off the main thread and avoiding per-item formatting in Composables.
- Precompute UI-friendly fields (formatted date/amount and stable keys) to lower composition cost on first render.
- Keep lightweight navigation behavior and prewarm heavy dependencies at app start to avoid cold-init stalls and fix back-dispatcher warning.

### Description
- Moved invoice collection processing and filter application to `Dispatchers.Default` using `withContext`, publishing only final `_uiState`/`_filterState` on the main thread (`InvoiceViewModel`).
- Introduced `InvoiceListItemUi` and changed `InvoiceUIState.Success` to expose `List<InvoiceListItemUi>` instead of raw domain `Invoice` objects, and added `Invoice.toUiItem()` mapper that precomputes `formattedDate` and `formattedAmount` once in the ViewModel.
- Updated `InvoiceItem` and `InvoicesScreen` to consume the new UI model, use `invoiceId` as a stable `LazyColumn` key, and adapted previews accordingly.
- Added `processInvoices`/`buildUpdatedFilterState`/`buildUiState` helpers and an `InvoiceProcessingResult` to keep processing logic off-main and return both filter state and UI state.
- Removed custom full-screen fade transitions from `MainActivity` so NavHost uses the default lighter transitions.
- Added warm-up initialization in `NexoSolarApplication` (background `warmUpScope` on `Dispatchers.IO`) to initialize `ApiClientManager` and open Room DB to reduce cold-start jank.
- Enabled `android:enableOnBackInvokedCallback="true"` in `AndroidManifest.xml` to address the `WindowOnBackDispatcher` warning.


------