### PR TITLE
Reduce InvoiceScreen jank: share shimmer animation and finalize off-main invoice processing

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
+        android:enableOnBackInvokedCallback="true"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"

--- a/app/src/main/java/com/nexosolar/android/NexoSolarApplication.kt
+++ b/app/src/main/java/com/nexosolar/android/NexoSolarApplication.kt
@@ -2,13 +2,29 @@ package com.nexosolar.android
 
 import android.app.Application
 import com.nexosolar.android.core.Logger
+import com.nexosolar.android.data.local.AppDatabase
+import com.nexosolar.android.data.remote.ApiClientManager
 import dagger.hilt.android.HiltAndroidApp
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 
 @HiltAndroidApp
 class NexoSolarApplication : Application() {
 
+    private val warmUpScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
     override fun onCreate() {
         super.onCreate()
         Logger.isDebug = BuildConfig.DEBUG
+
+        warmUpScope.launch {
+            // Precalentamos inicializaciones costosas para evitar jank
+            // al abrir por primera vez pantallas con Room/Retrofit.
+            ApiClientManager.init(this@NexoSolarApplication)
+            ApiClientManager.getApiService(useMock = true, useAlternativeUrl = false)
+            AppDatabase.getInstance(this@NexoSolarApplication).openHelper.writableDatabase
+        }
     }
 }

--- a/app/src/main/java/com/nexosolar/android/NexoSolarApplication.kt
+++ b/app/src/main/java/com/nexosolar/android/NexoSolarApplication.kt
@@ -1,6 +1,8 @@
 package com.nexosolar.android
 
 import android.app.Application
+import android.os.Looper
+import android.os.MessageQueue
 import com.nexosolar.android.core.Logger
 import com.nexosolar.android.data.local.AppDatabase
 import com.nexosolar.android.data.remote.ApiClientManager
@@ -8,6 +10,7 @@ import dagger.hilt.android.HiltAndroidApp
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 @HiltAndroidApp
@@ -19,12 +22,23 @@ class NexoSolarApplication : Application() {
         super.onCreate()
         Logger.isDebug = BuildConfig.DEBUG
 
-        warmUpScope.launch {
-            // Precalentamos inicializaciones costosas para evitar jank
-            // al abrir por primera vez pantallas con Room/Retrofit.
-            ApiClientManager.init(this@NexoSolarApplication)
-            ApiClientManager.getApiService(useMock = true, useAlternativeUrl = false)
-            AppDatabase.getInstance(this@NexoSolarApplication).openHelper.writableDatabase
-        }
+        // Programamos el warmup cuando el loop principal quede idle para no competir
+        // con el primer draw de MainActivity durante cold start.
+        Looper.getMainLooper().queue.addIdleHandler(
+            MessageQueue.IdleHandler {
+                warmUpScope.launch {
+                    // Pequeña espera para evitar contención CPU justo tras el primer frame.
+                    delay(400)
+
+                    ApiClientManager.init(this@NexoSolarApplication)
+
+                    // Precalentamos dependencias fuera de UI. Se mantiene en background
+                    // para amortizar el coste de primer uso sin bloquear arranque.
+                    ApiClientManager.getApiService(useMock = true, useAlternativeUrl = false)
+                    AppDatabase.getInstance(this@NexoSolarApplication).openHelper.writableDatabase
+                }
+                false
+            }
+        )
     }
 }

--- a/app/src/main/java/com/nexosolar/android/ui/invoices/InvoiceListItemUi.kt
+++ b/app/src/main/java/com/nexosolar/android/ui/invoices/InvoiceListItemUi.kt
@@ -1,0 +1,10 @@
+package com.nexosolar.android.ui.invoices
+
+import com.nexosolar.android.domain.models.InvoiceState
+
+data class InvoiceListItemUi(
+    val id: Int,
+    val dateText: String,
+    val amountText: String,
+    val state: InvoiceState
+)

--- a/app/src/main/java/com/nexosolar/android/ui/invoices/InvoiceUIState.kt
+++ b/app/src/main/java/com/nexosolar/android/ui/invoices/InvoiceUIState.kt
@@ -1,7 +1,6 @@
 package com.nexosolar.android.ui.invoices
 
 import com.nexosolar.android.core.ErrorClassifier
-import com.nexosolar.android.domain.models.Invoice
 import com.nexosolar.android.domain.models.InvoiceFilters
 
 /**
@@ -20,7 +19,7 @@ sealed interface InvoiceUIState {
      * @param isRefreshing Indica si hay una recarga en segundo plano (spinner pequeño).
      */
     data class Success(
-        val invoices: List<Invoice>,
+        val invoices: List<InvoiceListItemUi>,
         val isRefreshing: Boolean = false
     ) : InvoiceUIState
 

--- a/app/src/main/java/com/nexosolar/android/ui/invoices/InvoicesScreen.kt
+++ b/app/src/main/java/com/nexosolar/android/ui/invoices/InvoicesScreen.kt
@@ -1,5 +1,11 @@
 package com.nexosolar.android.ui.invoices
 
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -23,13 +29,11 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.nexosolar.android.R
-import com.nexosolar.android.domain.models.Invoice
 import com.nexosolar.android.ui.invoices.components.InvoiceItem
 import com.nexosolar.android.ui.invoices.components.InvoiceItemSkeleton
 import com.nexosolar.android.ui.invoices.components.NotAvailableDialog
 import com.nexosolar.android.ui.invoices.filter.InvoiceFilterScreen
 import com.nexosolar.android.ui.smartsolar.components.ErrorView
-import java.time.LocalDate
 
 // =================================================================
 // 1. ROUTE
@@ -198,7 +202,7 @@ private fun InvoiceContent(
                     ) {
                         items(
                             items = uiState.invoices,
-                            key = { it.invoiceID }
+                            key = { it.id }
                         ) { invoice ->
                             InvoiceItem(
                                 invoice = invoice,
@@ -273,12 +277,23 @@ private fun EmptyStateView() {
 
 @Composable
 private fun InvoiceListSkeleton() {
+    val shimmerTransition = rememberInfiniteTransition(label = "InvoiceSkeletonShimmer")
+    val shimmerTranslate by shimmerTransition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1000f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 1200, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart
+        ),
+        label = "InvoiceSkeletonTranslate"
+    )
+
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
         contentPadding = PaddingValues(vertical = 8.dp)
     ) {
-        items(count = 12, key = { "skeleton-$it" }) {
-            InvoiceItemSkeleton()
+        items(count = 8, key = { "skeleton-$it" }) {
+            InvoiceItemSkeleton(shimmerTranslate = shimmerTranslate)
         }
     }
 }
@@ -293,11 +308,11 @@ private fun InvoiceScreenSuccessPreview() {
     InvoiceScreen(
         uiState = InvoiceUIState.Success(
             invoices = listOf(
-                Invoice(invoiceID = 1, invoiceAmount = 54.56f, invoiceDate = LocalDate.of(2020, 8, 31), invoiceStatus = "Pendiente de pago"),
-                Invoice(invoiceID = 2, invoiceAmount = 67.54f, invoiceDate = LocalDate.of(2020, 7, 31), invoiceStatus = "Pagada"),
-                Invoice(invoiceID = 3, invoiceAmount = 56.38f, invoiceDate = LocalDate.of(2020, 6, 22), invoiceStatus = "Anulada"),
-                Invoice(invoiceID = 4, invoiceAmount = 150.75f, invoiceDate = LocalDate.of(2024, 5, 12), invoiceStatus = "Cuota fija"),
-                Invoice(invoiceID = 5, invoiceAmount = 99.99f, invoiceDate = LocalDate.of(2024, 6, 8), invoiceStatus = "Plan de pago"),
+                InvoiceListItemUi(id = 1, dateText = "31 ago 2020", amountText = "54,56 €", state = com.nexosolar.android.domain.models.InvoiceState.PENDING),
+                InvoiceListItemUi(id = 2, dateText = "31 jul 2020", amountText = "67,54 €", state = com.nexosolar.android.domain.models.InvoiceState.PAID),
+                InvoiceListItemUi(id = 3, dateText = "22 jun 2020", amountText = "56,38 €", state = com.nexosolar.android.domain.models.InvoiceState.CANCELLED),
+                InvoiceListItemUi(id = 4, dateText = "12 may 2024", amountText = "150,75 €", state = com.nexosolar.android.domain.models.InvoiceState.FIXED_FEE),
+                InvoiceListItemUi(id = 5, dateText = "8 jun 2024", amountText = "99,99 €", state = com.nexosolar.android.domain.models.InvoiceState.PAYMENT_PLAN),
             )
         ),
         onRefresh = {},

--- a/app/src/main/java/com/nexosolar/android/ui/invoices/components/InvoiceItem.kt
+++ b/app/src/main/java/com/nexosolar/android/ui/invoices/components/InvoiceItem.kt
@@ -22,21 +22,18 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.nexosolar.android.R
-import com.nexosolar.android.core.DateUtils
-import com.nexosolar.android.domain.models.Invoice
+import com.nexosolar.android.ui.invoices.InvoiceListItemUi
 import com.nexosolar.android.domain.models.InvoiceState
 import com.nexosolar.android.ui.theme.NexoSolarTheme
-import java.time.LocalDate
-import java.util.Locale
 
 
 
 @Composable
 fun InvoiceItem(
-    invoice: Invoice,
+    invoice: InvoiceListItemUi,
     onClick: () -> Unit
 ) {
-    val isPaid = invoice.estadoEnum == InvoiceState.PAID
+    val isPaid = invoice.state == InvoiceState.PAID
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -55,7 +52,7 @@ fun InvoiceItem(
                 modifier = Modifier.weight(1f)
             ) {
                 Text(
-                    text = DateUtils.formatDate(invoice.invoiceDate).ifEmpty { stringResource(R.string.sin_fecha) },
+                    text = invoice.dateText.ifEmpty { stringResource(R.string.sin_fecha) },
                     color = Color.Black,
                     fontSize = dimensionResource(id = R.dimen.invoice_item_date_text_size).value.sp,
                     fontWeight = FontWeight.Normal,
@@ -66,11 +63,11 @@ fun InvoiceItem(
                     )
                 )
 
-                if (invoice.estadoEnum != InvoiceState.PAID) {
+                if (invoice.state != InvoiceState.PAID) {
                     Spacer(modifier = Modifier.height(4.dp))
                     Text(
-                        text = stringResource(id = getStatusTextRes(invoice.estadoEnum)),
-                        color = getStatusColor(invoice.estadoEnum),
+                        text = stringResource(id = getStatusTextRes(invoice.state)),
+                        color = getStatusColor(invoice.state),
                         fontSize = dimensionResource(id = R.dimen.invoice_item_state_text_size).value.sp,
                         modifier = Modifier.padding(
                             start = dimensionResource(id = R.dimen.invoice_item_state_margin_start),
@@ -95,7 +92,7 @@ fun InvoiceItem(
                 horizontalArrangement = Arrangement.End
             ) {
                 Text(
-                    text = String.format(Locale.getDefault(), "%.2f €", invoice.invoiceAmount),
+                    text = invoice.amountText,
                     color = Color.Black,
                     fontSize = dimensionResource(id = R.dimen.invoice_item_amount_text_size).value.sp,
                     fontWeight = FontWeight.Normal,
@@ -151,10 +148,11 @@ private fun getStatusColor(state: InvoiceState): Color {
 private fun InvoiceItemPendingPreview() {
     NexoSolarTheme {
         InvoiceItem(
-            invoice = Invoice(
-                invoiceAmount = 150.50f,
-                invoiceDate = LocalDate.of(2023, 9, 10),
-                invoiceStatus = "Pendiente de pago" // String raw, pero el enum lo pilla
+            invoice = InvoiceListItemUi(
+                id = 1,
+                amountText = "150,50 €",
+                dateText = "10 sep 2023",
+                state = InvoiceState.PENDING
             ),
             onClick = {}
         )
@@ -166,10 +164,11 @@ private fun InvoiceItemPendingPreview() {
 private fun InvoiceItemPaidPreview() {
     NexoSolarTheme {
         InvoiceItem(
-            invoice = Invoice(
-                invoiceAmount = 89.99f,
-                invoiceDate = LocalDate.of(2023, 10, 25),
-                invoiceStatus = "Pagada" // Debería mapear a PAID
+            invoice = InvoiceListItemUi(
+                id = 2,
+                amountText = "89,99 €",
+                dateText = "25 oct 2023",
+                state = InvoiceState.PAID
             ),
             onClick = {}
         )

--- a/app/src/main/java/com/nexosolar/android/ui/invoices/components/InvoiceItemSkeleton.kt
+++ b/app/src/main/java/com/nexosolar/android/ui/invoices/components/InvoiceItemSkeleton.kt
@@ -1,16 +1,12 @@
 package com.nexosolar.android.ui.invoices.components
 
-import androidx.compose.animation.core.*
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.*
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -24,23 +20,9 @@ import com.nexosolar.android.ui.theme.NexoSolarTheme
 
 @Composable
 fun InvoiceItemSkeleton(
+    shimmerTranslate: Float,
     modifier: Modifier = Modifier
 ) {
-    // ✅ Animación que traslada el gradiente continuamente
-    val infiniteTransition = rememberInfiniteTransition(label = "Shimmer")
-    val translateAnim by infiniteTransition.animateFloat(
-        initialValue = 0f,
-        targetValue = 1000f, // Distancia del desplazamiento
-        animationSpec = infiniteRepeatable(
-            animation = tween(
-                durationMillis = 1200,
-                easing = LinearEasing
-            ),
-            repeatMode = RepeatMode.Restart
-        ),
-        label = "ShimmerTranslate"
-    )
-
     val isPaid = false
 
     Column(
@@ -55,9 +37,8 @@ fun InvoiceItemSkeleton(
             verticalAlignment = Alignment.Top
         ) {
             Column(modifier = Modifier.weight(1f)) {
-                // Fecha shimmer
                 ShimmerBox(
-                    translateAnim = translateAnim,
+                    shimmerTranslate = shimmerTranslate,
                     width = 150.dp,
                     height = dimensionResource(id = R.dimen.invoice_item_date_text_size),
                     modifier = Modifier.padding(
@@ -69,7 +50,7 @@ fun InvoiceItemSkeleton(
                 if (!isPaid) {
                     Spacer(modifier = Modifier.height(4.dp))
                     ShimmerBox(
-                        translateAnim = translateAnim,
+                        shimmerTranslate = shimmerTranslate,
                         width = 120.dp,
                         height = dimensionResource(id = R.dimen.invoice_item_state_text_size),
                         modifier = Modifier.padding(
@@ -87,14 +68,14 @@ fun InvoiceItemSkeleton(
                 horizontalArrangement = Arrangement.End
             ) {
                 ShimmerBox(
-                    translateAnim = translateAnim,
+                    shimmerTranslate = shimmerTranslate,
                     width = 90.dp,
                     height = dimensionResource(id = R.dimen.invoice_item_amount_text_size),
                     modifier = Modifier.padding(end = 15.dp)
                 )
 
                 ShimmerBox(
-                    translateAnim = translateAnim,
+                    shimmerTranslate = shimmerTranslate,
                     width = 20.dp,
                     height = 20.dp
                 )
@@ -109,16 +90,9 @@ fun InvoiceItemSkeleton(
     }
 }
 
-/**
- * Box con efecto shimmer deslizante.
- *
- * @param translateAnim Valor de traslación horizontal (0f → 1000f continuamente).
- * @param width Ancho del box.
- * @param height Alto del box.
- */
 @Composable
 private fun ShimmerBox(
-    translateAnim: Float,
+    shimmerTranslate: Float,
     width: Dp,
     height: Dp,
     modifier: Modifier = Modifier
@@ -126,139 +100,25 @@ private fun ShimmerBox(
     Box(
         modifier = modifier
             .size(width = width, height = height)
-            .clip(RoundedCornerShape(8.dp))
             .background(
                 brush = Brush.linearGradient(
                     colors = listOf(
-                        Color(0xFFE0E0E0), // Gris claro (base)
-                        Color(0xFFF5F5F5), // Blanco (brillo)
-                        Color(0xFFE0E0E0)  // Gris claro (base)
+                        Color(0xFFE0E0E0),
+                        Color(0xFFF5F5F5),
+                        Color(0xFFE0E0E0)
                     ),
-                    // ✅ La clave: start y end se mueven con translateAnim
-                    start = Offset(x = translateAnim - 200f, y = 0f),
-                    end = Offset(x = translateAnim + 200f, y = 0f)
-                )
+                    start = Offset(x = shimmerTranslate - 200f, y = 0f),
+                    end = Offset(x = shimmerTranslate + 200f, y = 0f)
+                ),
+                shape = RoundedCornerShape(8.dp)
             )
     )
 }
 
-// =================================================================
-// PREVIEWS SKELETON
-// =================================================================
-
-@Preview(showBackground = true, name = "Skeleton No Pagada")
+@Preview(showBackground = true, name = "Skeleton")
 @Composable
 private fun InvoiceItemSkeletonPreview() {
     NexoSolarTheme {
-        Surface(
-            modifier = Modifier.fillMaxSize(),
-            color = Color.White
-        ) {
-            InvoiceItemSkeleton()
-        }
-    }
-}
-
-@Preview(showBackground = true, name = "Skeleton Pagada (Sin estado)")
-@Composable
-private fun InvoiceItemSkeletonPagadaPreview() {
-    NexoSolarTheme {
-        Surface(
-            modifier = Modifier.fillMaxSize(),
-            color = Color.White
-        ) {
-            InvoiceItemSkeletonPagada()
-        }
-    }
-}
-/*
-@Preview(showBackground = true, name = "Lista Skeleton (12 items)")
-@Composable
-private fun InvoiceListSkeletonPreview() {
-    NexoSolarTheme {
-        Surface(
-            modifier = Modifier.fillMaxSize(),
-            color = Color.White
-        ) {
-            LazyColumn(
-                modifier = Modifier.fillMaxSize(),
-                contentPadding = PaddingValues(vertical = 8.dp),
-                verticalArrangement = Arrangement.spacedBy(0.dp)
-            ) {
-                items(count = 12, key = { it }) {
-                    InvoiceItemSkeleton()
-                }
-            }
-        }
-    }
-}
-*/
-
-
-// Helper para preview pagada
-@Composable
-private fun InvoiceItemSkeletonPagada() {
-    val infiniteTransition = rememberInfiniteTransition(label = "Shimmer")
-    val translateAnim by infiniteTransition.animateFloat(
-        initialValue = 0f,
-        targetValue = 1000f,
-        animationSpec = infiniteRepeatable(
-            animation = tween(1200, easing = LinearEasing),
-            repeatMode = RepeatMode.Restart
-        ),
-        label = "ShimmerTranslate"
-    )
-
-    val isPaid = true
-
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = dimensionResource(id = R.dimen.invoice_item_padding_horizontal))
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(vertical = if (isPaid) 22.dp else 16.dp),
-            verticalAlignment = Alignment.Top
-        ) {
-            Column(modifier = Modifier.weight(1f)) {
-                ShimmerBox(
-                    translateAnim = translateAnim,
-                    width = 90.dp,
-                    height = dimensionResource(id = R.dimen.invoice_item_date_text_size),
-                    modifier = Modifier.padding(
-                        start = dimensionResource(id = R.dimen.invoice_item_date_margin_start),
-                        top = 0.dp
-                    )
-                )
-            }
-
-            Row(
-                modifier = Modifier
-                    .align(Alignment.CenterVertically)
-                    .padding(end = 20.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.End
-            ) {
-                ShimmerBox(
-                    translateAnim = translateAnim,
-                    width = 80.dp,
-                    height = dimensionResource(id = R.dimen.invoice_item_amount_text_size),
-                    modifier = Modifier.padding(end = 15.dp)
-                )
-                ShimmerBox(
-                    translateAnim = translateAnim,
-                    width = 20.dp,
-                    height = 20.dp
-                )
-            }
-        }
-
-        HorizontalDivider(
-            modifier = Modifier.fillMaxWidth(),
-            thickness = dimensionResource(id = R.dimen.invoice_item_divider_height),
-            color = colorResource(id = R.color.invoice_item_divider_color)
-        )
+        InvoiceItemSkeleton(shimmerTranslate = 400f)
     }
 }

--- a/app/src/main/java/com/nexosolar/android/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/nexosolar/android/ui/main/MainActivity.kt
@@ -4,28 +4,18 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.animation.AnimatedContentTransitionScope
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.runtime.getValue
-import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.nexosolar.android.ui.invoices.InvoiceRoute
-import com.nexosolar.android.ui.smartsolar.InstallationViewModel
 import com.nexosolar.android.ui.smartsolar.SmartSolarRoute
-import com.nexosolar.android.ui.smartsolar.SmartSolarScreen
-import com.nexosolar.android.ui.smartsolar.details.DetailsScreen
-import com.nexosolar.android.ui.smartsolar.energy.EnergyScreen
-import com.nexosolar.android.ui.smartsolar.installation.InstallationScreen
 import com.nexosolar.android.ui.theme.NexoSolarTheme
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
@@ -37,11 +27,7 @@ class MainActivity : ComponentActivity() {
                 // CAMBIO CLAVE: El startDestination debe ser "main_menu"
                 NavHost(
                     navController = navController,
-                    startDestination = "main_menu",
-                    enterTransition = { fadeIn(animationSpec = tween(500)) },
-                    exitTransition = { fadeOut(animationSpec = tween(500)) },
-                    popEnterTransition = { fadeIn(animationSpec = tween(500)) },
-                    popExitTransition = { fadeOut(animationSpec = tween(500)) }
+                    startDestination = "main_menu"
                 ) {
                     // 1. Pantalla de Inicio
                     composable("main_menu") {


### PR DESCRIPTION
### Motivation
- Reduce remaining UI jank observed on first navigation where many simultaneous shimmer animations and heavy invoice processing caused skipped frames.
- Finish migrating invoice processing off the main thread and deliver UI-ready row models to avoid repeated formatting during composition.
- Prewarm heavy singletons at app startup and remove expensive full-screen navigation transitions to lower first-interaction cost.

### Description
- Refactored `InvoiceItemSkeleton` to accept a `shimmerTranslate: Float` parameter and removed per-row `rememberInfiniteTransition` so rows no longer create their own infinite animations. 
- Added a shared shimmer in `InvoiceListSkeleton` using a single `rememberInfiniteTransition` and passed the animated `shimmerTranslate` to each skeleton row, and reduced placeholder count from 12 to 8 to lower initial composition/draw work. 
- Consolidated invoice processing off the main thread in `InvoiceViewModel` by running collection/processing on `Dispatchers.Default`, introduced `processInvoices`, precomputed UI rows with new `InvoiceListItemUi`, and formatted dates/amounts in the ViewModel (using a synchronized `NumberFormat`).
- Updated UI code to consume the new model: `InvoiceItem` now accepts `InvoiceListItemUi`, `InvoicesScreen` uses stable keys (`id`) and the skeleton while loading, and previews were updated accordingly. 
- Prewarmed heavy singletons in `NexoSolarApplication` by launching a `warmUpScope` on `Dispatchers.IO` that initializes `ApiClientManager` and touches `AppDatabase.writableDatabase`. 
- Removed the full-screen fade transitions from `MainActivity` and enabled modern back-dispatch behavior by adding `android:enableOnBackInvokedCallback="true"` to `AndroidManifest.xml`.
