### PR TITLE
Guard invoice interactions during back navigation

### DIFF
--- a/app/src/main/java/com/nexosolar/android/ui/invoices/components/InvoiceDetailDialog.kt
+++ b/app/src/main/java/com/nexosolar/android/ui/invoices/components/InvoiceDetailDialog.kt
@@ -8,7 +8,6 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.nexosolar.android.R
-import androidx.compose.ui.window.DialogProperties
 
 
 /**
@@ -19,11 +18,7 @@ fun NotAvailableDialog(
     onDismiss: () -> Unit
 ) {
     AlertDialog(
-        onDismissRequest = {},
-        properties = DialogProperties(
-            dismissOnBackPress = false,
-            dismissOnClickOutside = false
-        ),
+        onDismissRequest = onDismiss,
         title = { Text(text = stringResource(R.string.informacion)) },
         text = { Text(text = stringResource(R.string.mensaje_funcionalidad_no_disponible)) },
         confirmButton = {


### PR DESCRIPTION
### Motivation
- Prevent race conditions where taps during or after back navigation open the "not available" dialog or filters while the route is being popped.  
- Centralize back handling so transient UI (`showFilters`, `showNotAvailableDialog`) can be cleared reliably before navigating away.  

### Description
- Added an `isNavigatingBack` state and a protected `handleBackClick` in `InvoiceRoute` that clears `showFilters` and `showNotAvailableDialog` and prevents re-entrancy.  
- Updated `BackHandler` to use the central `handleBackClick` and to close filters first if they are open.  
- Propagated `isNavigatingBack` and dialog callbacks through `InvoiceScreen` and `InvoiceContent`, disabled the top-bar back clickable and the filter action while navigating back, and guarded invoice item clicks with `if (!isNavigatingBack)`.  
- Made `NotAvailableDialog` dismissible via `onDismissRequest` and adjusted previews to the new `InvoiceScreen` signature.  

