### PR TITLE
Dark Mode support in MainScreen and themed switches

### DIFF
--- a/app/src/main/java/com/nexosolar/android/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/nexosolar/android/ui/main/MainScreen.kt
@@ -59,10 +59,12 @@ fun MainScreen(
     onNavigateToInvoices: () -> Unit,
     onNavigateToSmartSolar: () -> Unit
 ) {
+    val colorScheme = MaterialTheme.colorScheme
+
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(colorResource(id = R.color.main_background))
+            .background(colorScheme.background)
             .verticalScroll(rememberScrollState())
     ) {
         // 1. FONDO ABSTRACTO (Capa base, equivalente a ImageView con constraints)
@@ -104,8 +106,14 @@ fun MainScreen(
                         .padding(horizontal = 4.dp)
                         .defaultMinSize(minWidth = 1.dp, minHeight = 1.dp).height(0.dp).scale(0.8f),
                     colors = SwitchDefaults.colors(
-                        disabledUncheckedThumbColor = Color.Gray.copy(alpha = 0.5f),
-                        disabledUncheckedTrackColor = Color.Gray.copy(alpha = 0.3f)
+                        checkedThumbColor = colorScheme.primary,
+                        checkedTrackColor = colorScheme.primaryContainer,
+                        uncheckedThumbColor = colorScheme.outline,
+                        uncheckedTrackColor = colorScheme.surfaceVariant,
+                        disabledCheckedThumbColor = colorScheme.primary.copy(alpha = 0.4f),
+                        disabledCheckedTrackColor = colorScheme.primaryContainer.copy(alpha = 0.5f),
+                        disabledUncheckedThumbColor = colorScheme.outline.copy(alpha = 0.5f),
+                        disabledUncheckedTrackColor = colorScheme.surfaceVariant.copy(alpha = 0.6f)
                     )
                 )
 
@@ -124,7 +132,17 @@ fun MainScreen(
                     onCheckedChange = onMockToggled,
                     modifier = Modifier
                         .padding(end = 16.dp)
-                        .defaultMinSize(minWidth = 1.dp, minHeight = 1.dp).scale(0.8f)
+                        .defaultMinSize(minWidth = 1.dp, minHeight = 1.dp).scale(0.8f),
+                    colors = SwitchDefaults.colors(
+                        checkedThumbColor = colorScheme.secondary,
+                        checkedTrackColor = colorScheme.secondaryContainer,
+                        uncheckedThumbColor = colorScheme.outline,
+                        uncheckedTrackColor = colorScheme.surfaceVariant,
+                        disabledCheckedThumbColor = colorScheme.secondary.copy(alpha = 0.4f),
+                        disabledCheckedTrackColor = colorScheme.secondaryContainer.copy(alpha = 0.5f),
+                        disabledUncheckedThumbColor = colorScheme.outline.copy(alpha = 0.5f),
+                        disabledUncheckedTrackColor = colorScheme.surfaceVariant.copy(alpha = 0.6f)
+                    )
                 )
 
                 // Avatar
@@ -153,7 +171,7 @@ fun MainScreen(
                 text = stringResource(R.string.greeting_user, uiState.userName),
                 fontSize = 24.sp,
                 fontWeight = FontWeight.Bold,
-                color = Color.Black,
+                color = colorScheme.onBackground,
                 modifier = Modifier.padding(start = 16.dp, top = 16.dp)
             )
 
@@ -161,7 +179,7 @@ fun MainScreen(
             Text(
                 text = uiState.userAddress,
                 fontSize = 14.sp,
-                color = colorResource(id = R.color.darker_gray),
+                color = colorScheme.onSurfaceVariant,
                 maxLines = 1,
                 modifier = Modifier.padding(start = 16.dp, top = 4.dp, end = 16.dp)
             )
@@ -171,7 +189,7 @@ fun MainScreen(
                 text = stringResource(R.string.mi_energ_a),
                 fontWeight = FontWeight.Bold,
                 fontSize = 20.sp,
-                color = Color.Black,
+                color = colorScheme.onBackground,
                 modifier = Modifier.padding(start = 16.dp, top = 24.dp, bottom = 16.dp)
             )
 

--- a/app/src/main/res/drawable-night/bg_header_abstract.xml
+++ b/app/src/main/res/drawable-night/bg_header_abstract.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="@dimen/main_header_vector_width"
+    android:height="@dimen/main_header_vector_height"
+    android:viewportWidth="412"
+    android:viewportHeight="360">
+
+    <path
+        android:pathData="M0,0h412v360h-412z"
+        android:fillColor="#FF102014" />
+
+    <path
+        android:pathData="M0,220 Q103,235 206,220 T412,225 V360 H0 Z"
+        android:fillColor="#FF1C3A26" />
+
+    <path
+        android:pathData="M0,285 Q103,275 206,285 T412,290 V360 H0 Z"
+        android:fillColor="#FF2E5939" />
+
+    <path
+        android:pathData="M0,320 Q103,330 206,320 T412,320 V360 H0 Z"
+        android:fillColor="#FF121212" />
+
+</vector>


### PR DESCRIPTION
## Motivation

- Ensure the main screen respects `MaterialTheme` for background, text, and controls in dark mode, and that switches use theme-aware colors across all states.
- Add an abstract header variant for `night` that is automatically applied in dark mode.

## Description

- Replace the screen background in `MainScreen.kt` to use `MaterialTheme.colorScheme.background` instead of `R.color.main_background`.
- Update key text colors in `MainScreen.kt` to use `colorScheme.onBackground` and `colorScheme.onSurfaceVariant`.
- Customize both `Switch` components using `SwitchDefaults.colors(...)`, mapping checked/unchecked/disabled states to values from `colorScheme` in `MainScreen.kt`.
- Add `app/src/main/res/drawable-night/bg_header_abstract.xml` with a dark abstract version of the header so a different background is automatically applied in dark mode.

## Testing

- Attempted to compile using `./gradlew :app:compileDebugKotlin`, but the Gradle wrapper download failed due to network restrictions (proxy returned `HTTP/1.1 403 Forbidden`), so automatic compilation could not be completed.
- No additional automated unit tests were executed in this environment due to the same network limitation.